### PR TITLE
Download a single receipt PDF

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use std::io::Cursor;
 use serde::{Deserialize, Serialize};
 
 use receiptgo::ringgo::errors::Error;
@@ -62,6 +63,30 @@ impl AuthenticationRequest {
     }
 }
 
+#[derive(Default, Serialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct DownloadRequest {
+    identifier: String,
+    resource_type_id: u8,
+}
+
+impl DownloadRequest {
+    pub fn new(identifier: String) -> Self {
+        Self {
+            identifier: identifier,
+            resource_type_id: 1,
+        }
+    }
+}
+
+#[derive(Default, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct DownloadRequestResponse {
+    resource_access_token: String,
+    return_code: u8,
+    success: bool,
+}
+
 async fn get_authentication_token(
     username: String,
     password: String,
@@ -77,7 +102,7 @@ async fn get_authentication_token(
     auth_response.access_token
 }
 
-async fn retrieve_parking_sessions(access_token: String) -> Result<Option<ParkingSessions>, Error> {
+async fn retrieve_parking_sessions(access_token: &str) -> Result<Option<ParkingSessions>, Error> {
     let client = reqwest::Client::new();
     let response = client
         .get(parking_sessions_url())
@@ -102,6 +127,46 @@ async fn retrieve_parking_sessions(access_token: String) -> Result<Option<Parkin
     }
 }
 
+async fn request_receipt_pdf_download(access_token: &str, parking_session_id: &str) -> Result<String, Error> {
+    let params = DownloadRequest::new(parking_session_id.to_owned());
+    let client = reqwest::Client::new();
+    let response = client
+        .post(request_download_url())
+        .bearer_auth(access_token)
+        .json(&params)
+        .send()
+        .await
+        .unwrap();
+
+     match response.status() {
+         reqwest::StatusCode::OK => {
+             match response.json::<DownloadRequestResponse>().await {
+                 Ok(parsed) => Ok(parsed.resource_access_token),
+                 Err(_) => panic!("Error parsing JSON"),
+             }
+         }
+         reqwest::StatusCode::UNAUTHORIZED => {
+             Err(Error::Unauthorized)
+         }
+         _ => {
+             Err(Error::Unknown)
+         }
+    }
+}
+
+type DownloadResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+async fn download_receipt_pdf(access_token: &str, parking_session_id: String) -> DownloadResult<()> {
+    let download_token = request_receipt_pdf_download(&access_token, &parking_session_id).await.unwrap();
+    let file_name = "receipt.pdf";
+    let response = reqwest::get(download_url(&download_token)).await?;
+    let mut file = std::fs::File::create(file_name)?;
+    let mut content = Cursor::new(response.bytes().await?);
+    std::io::copy(&mut content, &mut file)?;
+
+    Ok(())
+}
+
 fn login_url() -> String {
     format!(
         "{api_url}{path}",
@@ -118,6 +183,23 @@ fn parking_sessions_url() -> String {
     )
 }
 
+fn request_download_url() -> String {
+    format!(
+        "{api_url}{path}",
+        api_url = RINGGO_API_BASE_URL,
+        path = "/resource/accesstoken"
+    )
+}
+
+fn download_url(parking_session_id: &str) -> String {
+    format!(
+        "{api_url}{path}{parking_session_id}",
+        api_url = RINGGO_API_BASE_URL,
+        path = "/user/session/receipt/",
+        parking_session_id = parking_session_id,
+    )
+}
+
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
@@ -125,12 +207,17 @@ async fn main() {
     let access_token =
         get_authentication_token(args.username, args.password, args.client_secret).await;
 
-    let parking_sessions = retrieve_parking_sessions(access_token).await.unwrap();
+    let parking_sessions = retrieve_parking_sessions(&access_token).await.unwrap();
 
     if let Some(ps) = parking_sessions {
-        println!("Parking sessions");
-        for session in ps.sessions.into_iter() {
-            println!("- {}", session.auditlink);
+        let first_parking_session = ps.sessions.into_iter().next();
+
+        let download_result = download_receipt_pdf(&access_token, first_parking_session.unwrap().auditlink).await;
+
+        if let Ok(_) = download_result {
+            println!("Downloaded receipt");
+        } else {
+            println!("Download failed");
         }
     } else {
         println!("No parking sessions");


### PR DESCRIPTION
Implements downloading a single receipt for the first parking session returned.

It's a bit scrappy, but it's honest work.